### PR TITLE
fix: remove unuse package

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "eslint-plugin-jsx-a11y": "6.5.1",
     "eslint-plugin-react": "7.29.4",
     "eslint-plugin-react-hooks": "4.5.0",
-    "graphql-codegen": "^0.4.0",
     "jest": "27.5.1",
     "nx": "14.1.9",
     "prettier": "^2.5.1",


### PR DESCRIPTION
in package.json if we have 2 package (duplicate)
`@graphql-codegen/cli` and `graphql-codegen` we can not run `yarn gen:gql` command

fix: remove `graphql-codegen`